### PR TITLE
Add headers for socket.h

### DIFF
--- a/lib/ipp/ippmodule.c
+++ b/lib/ipp/ippmodule.c
@@ -23,6 +23,8 @@
 #include <Python.h>
 #include "structmember.h"
 
+#include <sys/types.h>
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include "pv.h"
 


### PR DESCRIPTION
sys/socket.h and sys/types.h are required to build on FreeBSD