### PR TITLE
Python 3.11 support

### DIFF
--- a/lib/include/pv.h
+++ b/lib/include/pv.h
@@ -58,4 +58,10 @@
 #endif
 #endif
 
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
+static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
+{ ob->ob_type = type; }
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+#endif
+
 #endif

--- a/lib/ipp/ippmodule.c
+++ b/lib/ipp/ippmodule.c
@@ -931,7 +931,7 @@ PyMODINIT_FUNC initipp(void)  {
 
    if (PyType_Ready(&IPprefixType) < 0)
       RETURN;
-   Py_TYPE(&IPprefixType) = &PyType_Type;
+   Py_SET_TYPE(&IPprefixType, &PyType_Type);
 
 #if PYTHON3
    m = PyModule_Create(&ipp_module);

--- a/lib/natkit/natkit.c
+++ b/lib/natkit/natkit.c
@@ -722,10 +722,10 @@ PyObject *m=NULL;
    if (m == NULL) RETURN;
 
    if (PyType_Ready(&IPflowType) < 0) RETURN;
-   Py_TYPE(&IPflowType) = &PyType_Type;
+   Py_SET_TYPE(&IPflowType, &PyType_Type);
 
    if (PyType_Ready(&FlowHomeType) < 0) RETURN;
-   Py_TYPE(&FlowHomeType) = &PyType_Type;
+   Py_SET_TYPE(&FlowHomeType, &PyType_Type);
 
    Py_INCREF(&IPflowType);
    PyModule_AddObject(m, "IPflow", (PyObject *)&IPflowType);

--- a/lib/plt/icmp.c
+++ b/lib/plt/icmp.c
@@ -483,9 +483,9 @@ void initicmp(void) {
    if (PyType_Ready(&EchoType) < 0) return;
    if (PyType_Ready(&RedirectType) < 0) return;
 
-   Py_TYPE(&IcmpType) = &PyType_Type;
-   Py_TYPE(&EchoType) = &PyType_Type;
-   Py_TYPE(&RedirectType) = &PyType_Type;
+   Py_SET_TYPE(&IcmpType, &PyType_Type);
+   Py_SET_TYPE(&EchoType, &PyType_Type);
+   Py_SET_TYPE(&RedirectType, &PyType_Type);
 
    Py_INCREF(&IcmpType);
    PyModule_AddObject(plt_module, "icmp", (PyObject *)&IcmpType);

--- a/lib/plt/icmp6.c
+++ b/lib/plt/icmp6.c
@@ -690,11 +690,11 @@ void initicmp6(void) {
    if (PyType_Ready(&Param6Type) < 0) return;
    if (PyType_Ready(&Neighbour6Type) < 0) return;
 
-   Py_TYPE(&Icmp6Type) = &PyType_Type;
-   Py_TYPE(&Echo6Type) = &PyType_Type;
-   Py_TYPE(&Toobig6Type) = &PyType_Type;
-   Py_TYPE(&Param6Type) = &PyType_Type;
-   Py_TYPE(&Neighbour6Type) = &PyType_Type;
+   Py_SET_TYPE(&Icmp6Type, &PyType_Type);
+   Py_SET_TYPE(&Echo6Type, &PyType_Type);
+   Py_SET_TYPE(&Toobig6Type, &PyType_Type);
+   Py_SET_TYPE(&Param6Type, &PyType_Type);
+   Py_SET_TYPE(&Neighbour6Type, &PyType_Type);
 
    Py_INCREF(&Icmp6Type);
    PyModule_AddObject(plt_module, "icmp6", (PyObject *)&Icmp6Type);

--- a/lib/plt/internet.c
+++ b/lib/plt/internet.c
@@ -423,7 +423,7 @@ PyTypeObject InternetType = {
 void initinternet(void) {
    if (PyType_Ready(&InternetType) < 0) return;
 
-   Py_TYPE(&InternetType) = &PyType_Type;
+   Py_SET_TYPE(&InternetType, &PyType_Type);
 
    Py_INCREF(&InternetType);
    PyModule_AddObject(plt_module, "Internet", (PyObject *)&InternetType);

--- a/lib/plt/ip.c
+++ b/lib/plt/ip.c
@@ -289,7 +289,7 @@ PyTypeObject IpType = {
 void initip(void) {
    if (PyType_Ready(&IpType) < 0) return;
 
-   Py_TYPE(&IpType) = &PyType_Type;
+   Py_SET_TYPE(&IpType, &PyType_Type);
 
    Py_INCREF(&IpType);
    PyModule_AddObject(plt_module, "ip", (PyObject *)&IpType);

--- a/lib/plt/ip6.c
+++ b/lib/plt/ip6.c
@@ -182,7 +182,7 @@ PyTypeObject Ip6Type = {
 void initip6(void) {
    if (PyType_Ready(&Ip6Type) < 0) return;
 
-   Py_TYPE(&Ip6Type) = &PyType_Type;
+   Py_SET_TYPE(&Ip6Type, &PyType_Type);
 
    Py_INCREF(&Ip6Type);
    PyModule_AddObject(plt_module, "ip6", (PyObject *)&Ip6Type);

--- a/lib/plt/ipflow.c
+++ b/lib/plt/ipflow.c
@@ -151,7 +151,7 @@ PyTypeObject IPflowType = {
 
 void initipflow(void)  {
    if (PyType_Ready(&IPflowType) < 0) return;
-   Py_TYPE(&IPflowType) = &PyType_Type;
+   Py_SET_TYPE(&IPflowType, &PyType_Type);
 
    Py_INCREF(&IPflowType);
    PyModule_AddObject(plt_module, "IPflow", (PyObject *)&IPflowType);

--- a/lib/plt/layers.c
+++ b/lib/plt/layers.c
@@ -223,9 +223,9 @@ void initlayers(void) {
    if (PyType_Ready(&Layer3Type) < 0) return;
    if (PyType_Ready(&TransportType) < 0) return;
 
-   Py_TYPE(&Layer2Type) = &PyType_Type;
-   Py_TYPE(&Layer3Type) = &PyType_Type;
-   Py_TYPE(&TransportType) = &PyType_Type;
+   Py_SET_TYPE(&Layer2Type, &PyType_Type);
+   Py_SET_TYPE(&Layer3Type, &PyType_Type);
+   Py_SET_TYPE(&TransportType, &PyType_Type);
 
    PyModule_AddObject(plt_module, "TRACE_TYPE_ETH",
 		      PyLong_FromLong(TRACE_TYPE_ETH));

--- a/lib/plt/outputtrace.c
+++ b/lib/plt/outputtrace.c
@@ -294,9 +294,9 @@ PyTypeObject FilterType = {
 
 void initoutputtrace(void) {
    if (PyType_Ready(&OutputTraceType) < 0) return;
-   Py_TYPE(&OutputTraceType) = &PyType_Type;
+   Py_SET_TYPE(&OutputTraceType, &PyType_Type);
    if (PyType_Ready(&FilterType) < 0) return;
-   Py_TYPE(&FilterType) = &PyType_Type;
+   Py_SET_TYPE(&FilterType, &PyType_Type);
 
    PyModule_AddObject(plt_module, "O_APPEND",
       PyLong_FromLong(O_APPEND));

--- a/lib/plt/packet.c
+++ b/lib/plt/packet.c
@@ -582,7 +582,7 @@ PyTypeObject PacketType = {
 void initpacket(void) {
    if (PyType_Ready(&PacketType) < 0) return;
 
-   Py_TYPE(&PacketType) = &PyType_Type;
+   Py_SET_TYPE(&PacketType, &PyType_Type);
 
    Py_INCREF(&PacketType);
    PyModule_AddObject(plt_module, "packet", (PyObject *)&PacketType);

--- a/lib/plt/pltmodule.c
+++ b/lib/plt/pltmodule.c
@@ -374,7 +374,7 @@ PyMODINIT_FUNC initplt(void)  {
 
    if (PyType_Ready(&DataType) < 0) RETURN;
 
-   Py_TYPE(&DataType) = &PyType_Type;
+   Py_SET_TYPE(&DataType, &PyType_Type);
 
    Py_INCREF(&DataType);
    PyModule_AddObject(plt_module, "Data", (PyObject *)&DataType);

--- a/lib/plt/sctp.c
+++ b/lib/plt/sctp.c
@@ -386,12 +386,12 @@ PyTypeObject SctpChunkType = {
 
 void initsctp(void) {
    if (PyType_Ready(&SctpType) <= 0) {
-      Py_TYPE(&SctpType) = &PyType_Type;
+      Py_SET_TYPE(&SctpType, &PyType_Type);
       Py_INCREF(&SctpType);
       PyModule_AddObject(plt_module, "sctp", (PyObject *)&SctpType);
       }
    if (PyType_Ready(&SctpChunkType) <= 0) {
-      Py_TYPE(&SctpChunkType) = &PyType_Type;
+      Py_SET_TYPE(&SctpChunkType, &PyType_Type);
       Py_INCREF(&SctpChunkType);
       PyModule_AddObject(plt_module, "chunk", (PyObject *)&SctpChunkType);
       }

--- a/lib/plt/tcp.c
+++ b/lib/plt/tcp.c
@@ -497,7 +497,7 @@ PyTypeObject TcpType = {
 void inittcp(void) {
    if (PyType_Ready(&TcpType) < 0) return;
 
-   Py_TYPE(&TcpType) = &PyType_Type;
+   Py_SET_TYPE(&TcpType, &PyType_Type);
 
    Py_INCREF(&TcpType);
    PyModule_AddObject(plt_module, "tcp", (PyObject *)&TcpType);

--- a/lib/plt/trace.c
+++ b/lib/plt/trace.c
@@ -395,7 +395,7 @@ PyTypeObject TraceType = {
 void inittrace(void) {
    if (PyType_Ready(&TraceType) < 0) return;
 
-   Py_TYPE(&TraceType) = &PyType_Type;
+   Py_SET_TYPE(&TraceType, &PyType_Type);
 
    Py_INCREF(&TraceType);
    PyModule_AddObject(plt_module, "trace", (PyObject *)&TraceType);

--- a/lib/plt/udp.c
+++ b/lib/plt/udp.c
@@ -241,7 +241,7 @@ PyTypeObject UdpType = {
 void initudp(void) {
    if (PyType_Ready(&UdpType) < 0) return;
 
-   Py_TYPE(&UdpType) = &PyType_Type;
+   Py_SET_TYPE(&UdpType, &PyType_Type);
 
    Py_INCREF(&UdpType);
    PyModule_AddObject(plt_module, "udp", (PyObject *)&UdpType);


### PR DESCRIPTION
Py_TYPE() changed to a inline static function, replace it with Py_SET_TYPE(). Include a backwards compatibility macro.

See: [bpo-39573](https://bugs.python.org/issue?@action=redirect&bpo=39573)